### PR TITLE
Modified details

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ BIN_TARGETS := phxqueue/test/test_config_main phxqueue/test/test_consumer_main p
 			   phxqueue_phxrpc/test/test_load_config_main phxqueue_phxrpc/test/test_rpc_config_main \
 			   phxqueue_phxrpc/test/consumer_main phxqueue_phxrpc/test/producer_benchmark_main \
 			   phxqueue_phxrpc/test/test_producer_echo_main phxqueue_phxrpc/test/config_check_main \
-			   phxqueue_phxrpc/test/test_selector_main
+			   phxqueue_phxrpc/test/test_selector_main phxqueue_phxrpc/test/test_get_main
 
 SUB_MAKE_LIB_TARGETS := phxqueue_phxrpc/app/store/libstore_client.a \
 						phxqueue_phxrpc/app/lock/liblock_client.a \

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Contact us: phxteam@tencent.com
 
 *	Strictly ordered dequeue
 
-*	Multiple subscribers
+*	Multiple consumer groups
 
 *	Dequeue speed limits
 
@@ -191,7 +191,7 @@ tail -f log/consumer.2/consumer_main.INFO
 This is an example of the output you can expect from the Consumer log:
 
 ```
-INFO: Dequeue ret 0 topic 1000 sub_id 1 store_id 1 queue_id 44 size 1 prev_cursor_id 9106 next_cursor_id 9109
+INFO: Dequeue ret 0 topic 1000 consumer_group_id 1 store_id 1 queue_id 44 size 1 prev_cursor_id 9106 next_cursor_id 9109
 ```
 
 ### Clearing data and logs created during testing

--- a/README.zh_cn.md
+++ b/README.zh_cn.md
@@ -14,7 +14,7 @@ PhxQueue是微信开源的一款基于Paxos协议实现的高可用、高吞吐�
 
 * 出入队严格有序
 
-* 多订阅
+* 多消费组
 
 * 出队限速
 
@@ -189,7 +189,7 @@ tail -f log/consumer.2/consumer_main.INFO
 你会发现有类似这样的Consumer消费出队请求的日志：
 
 ```
-INFO: Dequeue ret 0 topic 1000 sub_id 1 store_id 1 queue_id 44 size 1 prev_cursor_id 9106 next_cursor_id 9109
+INFO: Dequeue ret 0 topic 1000 consumer_group_id 1 store_id 1 queue_id 44 size 1 prev_cursor_id 9106 next_cursor_id 9109
 ```
 
 ### 清理测试日志和数据

--- a/etc/topicconfig.conf
+++ b/etc/topicconfig.conf
@@ -17,14 +17,14 @@
     [
         {
             "pub_id": "1",
-            "sub_ids": ["1"],
+            "consumer_group_ids": ["1"],
             "queue_info_ids": ["1"]
         }
     ],
-    "subs":
+    "consumer_groups":
     [
         {
-            "sub_id": "1",
+            "consumer_group_id": "1",
             "use_dynamic_scale": "0",
             "skip_lock": "1"
         }

--- a/phxqueue/comm/breakpoint.cpp
+++ b/phxqueue/comm/breakpoint.cpp
@@ -151,13 +151,13 @@ ProducerBP *ProducerBP::GetThreadInstance() {
     return bp;
 }
 
-ProducerSubBP *ProducerSubBP::GetThreadInstance() {
-    static thread_local ProducerSubBP *bp{nullptr};
+ProducerConsumerGroupBP *ProducerConsumerGroupBP::GetThreadInstance() {
+    static thread_local ProducerConsumerGroupBP *bp{nullptr};
     if (!bp) {
-        bp = plugin::BreakPointFactory::GetInstance()->NewProducerSubBP().release();
+        bp = plugin::BreakPointFactory::GetInstance()->NewProducerConsumerGroupBP().release();
     }
     if (!bp) {
-        bp = new ProducerSubBP();
+        bp = new ProducerConsumerGroupBP();
     }
     assert(bp);
 

--- a/phxqueue/comm/breakpoint.h
+++ b/phxqueue/comm/breakpoint.h
@@ -92,19 +92,19 @@ class ConsumerHeartBeatLockBP {
 
     virtual void OnSync(const int topic_id) {}
     virtual void OnProcUsed(const int topic_id, const int nproc, const int proc_used) {}
-    virtual void OnScaleHash(const int topic_id, const int sub_id, const uint32_t scale_hash) {}
-    virtual void OnAdjustScale(const int topic_id, const int sub_id) {}
+    virtual void OnScaleHash(const int topic_id, const int consumer_group_id, const uint32_t scale_hash) {}
+    virtual void OnAdjustScale(const int topic_id, const int consumer_group_id) {}
     virtual void OnProcUsedExceed(const int topic_id, const int nproc, const int proc_used) {}
     virtual void OnSyncSucc(const int topic_id) {}
     virtual void OnSyncFail(const int topic_id) {}
 
-    virtual void OnLock(const int topic_id, const int sub_id, const int store_id, const int queue_id) {}
+    virtual void OnLock(const int topic_id, const int consumer_group_id, const int store_id, const int queue_id) {}
     virtual void OnProcLack(const int topic_id) {}
     virtual void OnNoLockTarget(const int topic_id) {}
-    virtual void OnSkipLock(const int topic_id, const int sub_id) {}
+    virtual void OnSkipLock(const int topic_id, const int consumer_group_id) {}
     virtual void OnConcurrentIdempotent(const int topic_id, const int queue_info_id) {}
-    virtual void OnLockSucc(const int topic_id, const int sub_id, const int store_id, const int queue_id) {}
-    virtual void OnLockFail(const int topic_id, const int sub_id, const int store_id, const int queue_id) {}
+    virtual void OnLockSucc(const int topic_id, const int consumer_group_id, const int store_id, const int queue_id) {}
+    virtual void OnLockFail(const int topic_id, const int consumer_group_id, const int store_id, const int queue_id) {}
 };
 
 class StoreBP {
@@ -204,7 +204,7 @@ class StoreBacklogBP {
     StoreBacklogBP() {}
     virtual ~StoreBacklogBP() {}
 
-    virtual void OnBackLogReport(const int topic_id, const int sub_id, const int queue_id, const int backlog) {}
+    virtual void OnBackLogReport(const int topic_id, const int consumer_group_id, const int queue_id, const int backlog) {}
 };
 
 class StoreSMBP {
@@ -258,14 +258,14 @@ class ProducerBP {
 
 };
 
-class ProducerSubBP {
+class ProducerConsumerGroupBP {
   public:
-    static ProducerSubBP *GetThreadInstance();
+    static ProducerConsumerGroupBP *GetThreadInstance();
 
-    ProducerSubBP() {}
-    virtual ~ProducerSubBP() {}
+    ProducerConsumerGroupBP() {}
+    virtual ~ProducerConsumerGroupBP() {}
 
-    virtual void OnSubDistribute(const int topic_id, const int pub_id, const int handle_id, const uint64_t uin, const std::set<int> *sub_ids) {}
+    virtual void OnConsumerGroupDistribute(const int topic_id, const int pub_id, const int handle_id, const uint64_t uin, const std::set<int> *consumer_group_ids) {}
 };
 
 

--- a/phxqueue/comm/errdef.h
+++ b/phxqueue/comm/errdef.h
@@ -68,7 +68,7 @@ enum class RetCode {
     RET_ERR_RANGE_RANK = -10108,
     RET_ERR_RANGE_CNT = -10109,
     RET_ERR_RANGE_PUB = -10110,
-    RET_ERR_RANGE_SUB = -10111,
+    RET_ERR_RANGE_CONSUMER_GROUP = -10111,
     RET_ERR_RANGE_ADDR = -10112,
     RET_ERR_RANGE_SCHEDULER = -10113,  // scheduler_id 不合法
     RET_ERR_RANGE_LOCK = -10114,  // lock_id 不合法

--- a/phxqueue/comm/proto/comm.proto
+++ b/phxqueue/comm/proto/comm.proto
@@ -84,6 +84,8 @@ message GetRequest {
     optional uint64 prev_cursor_id = 11;
     optional uint64 next_cursor_id = 12;
 
+    optional bool random = 21;
+
     optional Addr master_addr = 100;
 }
 

--- a/phxqueue/comm/proto/comm.proto
+++ b/phxqueue/comm/proto/comm.proto
@@ -15,7 +15,7 @@ message Meta { // 不变量
     optional int32 topic_id = 2;
     optional int32 handle_id = 3;
     optional uint64 uin    = 5;
-    optional uint64 sub_ids = 8;
+    optional uint64 consumer_group_ids = 8;
     optional int32 pub_id = 9;
     optional uint64 hash = 11;
     optional uint64 atime  = 51;
@@ -28,7 +28,7 @@ message Meta { // 不变量
 message QItem {
     optional bytes  buffer = 6;
     optional int32 buffer_type  = 7;
-    optional uint64 sub_ids = 8;
+    optional uint64 consumer_group_ids = 8;
     optional int32 pub_id = 9;
     optional uint64 atime  = 51;
     optional uint32 atime_ms  = 52;
@@ -43,7 +43,7 @@ message QItem {
 
 message ConsumerContext {
     optional int32 topic_id = 1;
-    optional int32 sub_id = 2 [default = -1];
+    optional int32 consumer_group_id = 2 [default = -1];
     optional int32 store_id = 4 [default = -1];
     optional int32 queue_id = 5 [default = -1];
     optional uint64 prev_cursor_id = 6 [default = 0xffffffffffffffff];
@@ -78,7 +78,7 @@ message GetRequest {
     optional int32 queue_id = 3;
     optional int32 limit = 5;
     optional uint64 atime  = 6;
-    optional int32 sub_id = 7; // 如果sub_id在target_sub_ids中，那就拉取
+    optional int32 consumer_group_id = 7; // 如果consumer_group_id在target_consumer_group_ids中，那就拉取
     optional uint32 atime_ms  = 8;
 
     optional uint64 prev_cursor_id = 11;

--- a/phxqueue/config/consumerconfig.cpp
+++ b/phxqueue/config/consumerconfig.cpp
@@ -46,24 +46,24 @@ comm::RetCode ConsumerConfig::ReadConfig(proto::ConsumerConfig &proto) {
 
     consumer = proto.add_consumers();
     consumer->set_scale(100);
-    consumer->add_sub_ids(1);
-    consumer->add_sub_ids(2);
+    consumer->add_consumer_group_ids(1);
+    consumer->add_consumer_group_ids(2);
     addr = consumer->mutable_addr();
     addr->set_ip("127.0.0.1");
     addr->set_port(8001);
 
     consumer = proto.add_consumers();
     consumer->set_scale(100);
-    consumer->add_sub_ids(1);
-    consumer->add_sub_ids(2);
+    consumer->add_consumer_group_ids(1);
+    consumer->add_consumer_group_ids(2);
     addr = consumer->mutable_addr();
     addr->set_ip("127.0.0.1");
     addr->set_port(8002);
 
     consumer = proto.add_consumers();
     consumer->set_scale(100);
-    consumer->add_sub_ids(1);
-    consumer->add_sub_ids(2);
+    consumer->add_consumer_group_ids(1);
+    consumer->add_consumer_group_ids(2);
     addr = consumer->mutable_addr();
     addr->set_ip("127.0.0.1");
     addr->set_port(8003);

--- a/phxqueue/config/proto/consumerconfig.proto
+++ b/phxqueue/config/proto/consumerconfig.proto
@@ -10,5 +10,5 @@ message ConsumerConfig {
 message Consumer {
     optional comm.proto.Addr addr = 2;
     optional int32 scale = 3;
-    repeated int32 sub_ids = 20;
+    repeated int32 consumer_group_ids = 20;
 }

--- a/phxqueue/config/proto/topicconfig.proto
+++ b/phxqueue/config/proto/topicconfig.proto
@@ -6,7 +6,7 @@ message TopicConfig {
     optional Topic topic = 1;
     repeated QueueInfo queue_infos = 3;
     repeated Pub pubs = 5;
-    repeated Sub subs = 6;
+    repeated ConsumerGroup consumer_groups = 6;
     repeated SkipInfo skip_infos = 7;
     repeated FreqInfo freq_infos = 8;
     repeated ReplayInfo replay_infos = 9;
@@ -50,7 +50,7 @@ message Topic {
 
     optional int32 consumer_lock_lease_time_s = 601 [default = 30]; // lease time of consumer handling a queue. (default value recommanded)
     optional int32 consumer_max_mem_size_mb_per_proc = 602 [default = 300]; // consumer process suicide when memory reach consumer_max_mem_size_mb_per_proc.
-    repeated int32 consumer_ignore_sub_ids = 603; // sub_id list that consumer do not handle.
+    repeated int32 consumer_ignore_consumer_group_ids = 603; // consumer_group_id list that consumer do not handle.
     optional int32 consumer_lock_interval_s = 604 [default = 20]; // interval time of consumer refresh lease. must be less than consumer_lock_lease_time_s. (default value recommanded)
     optional int32 consumer_max_loop_per_proc = 606 [default = 0]; // consumer process suicide when process count reach consumer_max_loop_per_proc.
 
@@ -133,29 +133,29 @@ message QueueInfo {
 message Pub {
     optional int32 pub_id = 1; // (required, unique)
     repeated int32 queue_info_ids = 2; // multi queue_info_id. enqueue to next queue_info after the number of retries of current queue_info's count specify. (required)
-    repeated int32 sub_ids = 3; // multi-subscription routing. The meaning here is that the request belonging to the pub will be subscribed multi copies. (required)
+    repeated int32 consumer_group_ids = 3; // multi-consumption routing. The meaning here is that the request belonging to the pub will be consumed multi copies. (required)
 }
 
-message Sub {
-    optional int32 sub_id = 1; // (required, unique)
+message ConsumerGroup {
+    optional int32 consumer_group_id = 1; // (required, unique)
 
     optional int32 use_dynamic_scale = 11 [default = 1]; // use loadbalance.
     optional int32 skip_lock = 12 [default = 0]; // consumer do not use lock to exclusive queue
 }
 
-// skip item config. the relation of conditions(uin/pub_id/sub_id/queue_info_id/handle_id) is &.
+// skip item config. the relation of conditions(uin/pub_id/consumer_group_id/queue_info_id/handle_id) is &.
 message SkipInfo {
     optional uint32 uin = 1 [default = 0];
     optional int32 pub_id = 2 [default = -1];
-    optional int32 sub_id = 3 [default = -1];
+    optional int32 consumer_group_id = 3 [default = -1];
     optional int32 queue_info_id = 4 [default = -1];
     optional int32 handle_id = 5 [default = -1];
 }
 
-// consumer process freq config. the relation of conditions(pub_id/sub_id/handle_id/queue_info_id) is &.
+// consumer process freq config. the relation of conditions(pub_id/consumer_group_id/handle_id/queue_info_id) is &.
 message FreqInfo {
     optional int32 pub_id = 1;
-    optional int32 sub_id = 2;
+    optional int32 consumer_group_id = 2;
     optional int32 handle_id = 3 [default = -1];
     optional int32 limit_per_min = 4;
     optional int32 queue_info_id = 5;
@@ -163,7 +163,7 @@ message FreqInfo {
 
 // replay dequeue from cursor_id.
 message ReplayInfo {
-    repeated int32 sub_ids = 3;
+    repeated int32 consumer_group_ids = 3;
     repeated int32 pub_ids = 4;
 
     optional uint64 cursor_id = 61 [default = 0xffffffffffffffff];

--- a/phxqueue/config/topicconfig.h
+++ b/phxqueue/config/topicconfig.h
@@ -42,16 +42,16 @@ class TopicConfig : public BaseConfig<proto::TopicConfig> {
 
     comm::RetCode GetPubByPubID(const int pub_id, std::shared_ptr<const proto::Pub> &pub) const;
 
-    comm::RetCode GetSubIDsByPubID(const int pub_id, std::set<int> &sub_ids) const;
+    comm::RetCode GetConsumerGroupIDsByPubID(const int pub_id, std::set<int> &consumer_group_ids) const;
 
-    // sub
-    comm::RetCode GetAllSub(std::vector<std::shared_ptr<const proto::Sub>> &subs) const;
+    // consumer_group
+    comm::RetCode GetAllConsumerGroup(std::vector<std::shared_ptr<const proto::ConsumerGroup>> &consumer_groups) const;
 
-    comm::RetCode GetAllSubID(std::set<int> &sub_ids) const;
+    comm::RetCode GetAllConsumerGroupID(std::set<int> &consumer_group_ids) const;
 
-    bool IsValidSubID(const int sub_id) const;
+    bool IsValidConsumerGroupID(const int consumer_group_id) const;
 
-    comm::RetCode GetSubBySubID(const int sub_id, std::shared_ptr<const proto::Sub> &sub) const;
+    comm::RetCode GetConsumerGroupByConsumerGroupID(const int consumer_group_id, std::shared_ptr<const proto::ConsumerGroup> &consumer_group) const;
 
     // queue info
 
@@ -59,7 +59,7 @@ class TopicConfig : public BaseConfig<proto::TopicConfig> {
 
     comm::RetCode GetQueueInfoIDRankByPubID(const int queue_info_id, const int pub_id, uint64_t &rank) const;
 
-    bool IsValidQueue(const int queue, const int pub_id = -1, const int sub_id = -1) const;
+    bool IsValidQueue(const int queue, const int pub_id = -1, const int consumer_group_id = -1) const;
 
     comm::RetCode GetQueuesByQueueInfoID(const int queue_info_id, std::set<int> &queues) const;
 
@@ -75,7 +75,7 @@ class TopicConfig : public BaseConfig<proto::TopicConfig> {
 
     comm::RetCode GetQueueInfoByQueueInfoID(const int queue_info_id, std::shared_ptr<const proto::QueueInfo> &queue_info) const;
 
-    bool ShouldSkip(const comm::proto::QItem &item, const int sub_id, const int queue_info_id) const;
+    bool ShouldSkip(const comm::proto::QItem &item, const int consumer_group_id, const int queue_info_id) const;
 
     comm::RetCode GetQueueInfoIDByCount(const int pub_id, const int cnt, int &queue_info_id) const;
 

--- a/phxqueue/config/utils.h
+++ b/phxqueue/config/utils.h
@@ -13,5 +13,5 @@ Unless required by applicable law or agreed to in writing, software distributed 
 #pragma once
 
 #include "./utils/pub_util.h"
-#include "./utils/sub_util.h"
+#include "./utils/consumer_group_util.h"
 

--- a/phxqueue/config/utils/consumer_group_util.cpp
+++ b/phxqueue/config/utils/consumer_group_util.cpp
@@ -17,8 +17,8 @@ namespace utils {
 using namespace std;
 
 
-comm::RetCode GetSubIDsByConsumerAddr(const int topic_id, const comm::proto::Addr &addr, std::set<int> &sub_ids) {
-    sub_ids.clear();
+comm::RetCode GetConsumerGroupIDsByConsumerAddr(const int topic_id, const comm::proto::Addr &addr, std::set<int> &consumer_group_ids) {
+    consumer_group_ids.clear();
 
     comm::RetCode ret;
 
@@ -40,28 +40,28 @@ comm::RetCode GetSubIDsByConsumerAddr(const int topic_id, const comm::proto::Add
         return ret;
     }
 
-    set<int> ignore_sub_ids;
-    for (int i{0}; i < topic_config->GetProto().topic().consumer_ignore_sub_ids_size(); ++i) {
-        ignore_sub_ids.insert(topic_config->GetProto().topic().consumer_ignore_sub_ids(i));
+    set<int> ignore_consumer_group_ids;
+    for (int i{0}; i < topic_config->GetProto().topic().consumer_ignore_consumer_group_ids_size(); ++i) {
+        ignore_consumer_group_ids.insert(topic_config->GetProto().topic().consumer_ignore_consumer_group_ids(i));
     }
 
-    if (consumer->sub_ids_size()) {
-        for (int i{0}; i < consumer->sub_ids_size(); ++i) {
-            auto sub_id = consumer->sub_ids(i);
-            if (topic_config->IsValidSubID(sub_id) && ignore_sub_ids.end() == ignore_sub_ids.find(sub_id)) {
-                sub_ids.insert(sub_id);
+    if (consumer->consumer_group_ids_size()) {
+        for (int i{0}; i < consumer->consumer_group_ids_size(); ++i) {
+            auto consumer_group_id = consumer->consumer_group_ids(i);
+            if (topic_config->IsValidConsumerGroupID(consumer_group_id) && ignore_consumer_group_ids.end() == ignore_consumer_group_ids.find(consumer_group_id)) {
+                consumer_group_ids.insert(consumer_group_id);
             }
         }
         return comm::RetCode::RET_OK;
     }
 
-    if (comm::RetCode::RET_OK != (ret = topic_config->GetAllSubID(sub_ids))) {
-        NLErr("GetAllSubID ret %d", comm::as_integer(ret));
+    if (comm::RetCode::RET_OK != (ret = topic_config->GetAllConsumerGroupID(consumer_group_ids))) {
+        NLErr("GetAllConsumerGroupID ret %d", comm::as_integer(ret));
         return ret;
     }
 
-    for (auto &&ignore_sub_id : ignore_sub_ids) {
-        sub_ids.erase(ignore_sub_id);
+    for (auto &&ignore_consumer_group_id : ignore_consumer_group_ids) {
+        consumer_group_ids.erase(ignore_consumer_group_id);
     }
 
     return comm::RetCode::RET_OK;

--- a/phxqueue/config/utils/consumer_group_util.h
+++ b/phxqueue/config/utils/consumer_group_util.h
@@ -12,7 +12,7 @@ namespace config {
 namespace utils {
 
 
-comm::RetCode GetSubIDsByConsumerAddr(const int topic_id, const comm::proto::Addr &addr, std::set<int> &sub_ids);
+comm::RetCode GetConsumerGroupIDsByConsumerAddr(const int topic_id, const comm::proto::Addr &addr, std::set<int> &consumer_group_ids);
 
 
 }  // namespace utils

--- a/phxqueue/consumer/consumer.h
+++ b/phxqueue/consumer/consumer.h
@@ -34,7 +34,7 @@ struct Queue_t {
     uint32_t magic;
 
     // 共享内存中缓存队列信息, 重启后不丢失
-    uint32_t sub_id;
+    uint32_t consumer_group_id;
     uint32_t pub_id;
     uint32_t store_id;
     uint32_t queue_id;
@@ -47,7 +47,7 @@ struct QueueBuf_t {
 #pragma pack()
 
 using AddrScales = std::vector<comm::proto::AddrScale>;
-using SubID2AddrScales = std::map<int, AddrScales>;
+using ConsumerGroupID2AddrScales = std::map<int, AddrScales>;
 
 class Consumer : public comm::MultiProc {
   public:
@@ -154,7 +154,7 @@ class Consumer : public comm::MultiProc {
                               const std::vector<std::shared_ptr<comm::proto::QItem> > &items,
                               const std::vector<comm::HandleResult> &handle_results);
 
-    // In a consume process, there are multiple sub processes concurrently, each corresponding to a worker routine:
+    // In a consume process, there are multiple consumer_group processes concurrently, each corresponding to a worker routine:
     // 1. numbers of hanlde process, specified by ConsumerOption::nhandler, each handle items with same uin.
     // 2. numbers of batch handle process, specified by ConsumerOption::nbatch_handler, each handle all items from last pull.
     

--- a/phxqueue/consumer/hblock.h
+++ b/phxqueue/consumer/hblock.h
@@ -35,15 +35,15 @@ class HeartBeatLock {
 
     comm::RetCode Init(Consumer *consumer, const int shmkey, const std::string &lockpath, const int nproc);
     void RunSync();
-    comm::RetCode Lock(const int vpid, int &sub_id, int &store_id, int &queue_id);
+    comm::RetCode Lock(const int vpid, int &consumer_group_id, int &store_id, int &queue_id);
     comm::RetCode GetQueuesDistribute(std::vector<Queue_t> &queues);
 
   protected:
     comm::RetCode Sync();
-    void ClearInvalidSubIDs(const std::set<int> &valid_sub_ids);
-    void DistubePendingQueues(const std::map<int, std::vector<Queue_t>> &sub_id2pending_queues);
-    comm::RetCode GetAddrScale(SubID2AddrScales &sub_id2addr_scales);
-    comm::RetCode GetAllQueues(const int sub_id, std::vector<Queue_t> &all_queues);
+    void ClearInvalidConsumerGroupIDs(const std::set<int> &valid_consumer_group_ids);
+    void DistubePendingQueues(const std::map<int, std::vector<Queue_t>> &consumer_group_id2pending_queues);
+    comm::RetCode GetAddrScale(ConsumerGroupID2AddrScales &consumer_group_id2addr_scales);
+    comm::RetCode GetAllQueues(const int consumer_group_id, std::vector<Queue_t> &all_queues);
     comm::RetCode GetPendingQueues(const std::vector<Queue_t> &all_queues, const AddrScales &addr_scales, std::vector<Queue_t> &pending_queues);
     comm::RetCode DoLock(const int vpid, Queue_t *const info);
     void UpdateProcUsed();

--- a/phxqueue/plugin/breakpointfactory.cpp
+++ b/phxqueue/plugin/breakpointfactory.cpp
@@ -79,8 +79,8 @@ unique_ptr<comm::ProducerBP> BreakPointFactory::NewProducerBP() {
     return unique_ptr<comm::ProducerBP>(new comm::ProducerBP());
 }
 
-unique_ptr<comm::ProducerSubBP> BreakPointFactory::NewProducerSubBP() {
-    return unique_ptr<comm::ProducerSubBP>(new comm::ProducerSubBP());
+unique_ptr<comm::ProducerConsumerGroupBP> BreakPointFactory::NewProducerConsumerGroupBP() {
+    return unique_ptr<comm::ProducerConsumerGroupBP>(new comm::ProducerConsumerGroupBP());
 }
 
 

--- a/phxqueue/plugin/breakpointfactory.h
+++ b/phxqueue/plugin/breakpointfactory.h
@@ -34,7 +34,7 @@ class StoreBacklogBP;
 class StoreSMBP;
 
 class ProducerBP;
-class ProducerSubBP;
+class ProducerConsumerGroupBP;
 
 class SchedulerBP;
 class SchedulerMgrBP;
@@ -85,7 +85,7 @@ class BreakPointFactory {
     virtual std::unique_ptr<comm::StoreSMBP> NewStoreSMBP();
 
     virtual std::unique_ptr<comm::ProducerBP> NewProducerBP();
-    virtual std::unique_ptr<comm::ProducerSubBP> NewProducerSubBP();
+    virtual std::unique_ptr<comm::ProducerConsumerGroupBP> NewProducerConsumerGroupBP();
 
     virtual std::unique_ptr<comm::SchedulerBP> NewSchedulerBP();
     virtual std::unique_ptr<comm::SchedulerMgrBP> NewSchedulerMgrBP();

--- a/phxqueue/producer/producer.h
+++ b/phxqueue/producer/producer.h
@@ -44,7 +44,7 @@ class Producer {
     // Interface for Data first enqueue.
     // Pack argument info item, add to Store by Store::Add.
     comm::RetCode Enqueue(const int topic_id, const uint64_t uin, const int handle_id, const std::string &buffer,
-                          int pub_id = -1, const std::set<int> *sub_ids = nullptr, const std::string client_id = "");
+                          int pub_id = -1, const std::set<int> *consumer_group_ids = nullptr, const std::string client_id = "");
 
 
     // ------------------------ Interfaces used in Reenqueue scene  ------------------------

--- a/phxqueue/store/basemgr.cpp
+++ b/phxqueue/store/basemgr.cpp
@@ -136,13 +136,13 @@ bool BaseMgr::NeedSkipAdd(const uint64_t cursor_id, const comm::proto::AddReques
     }
 
     SyncCtrl *sync = impl_->store->GetSyncCtrl();
-    for (size_t i{0}; i < pub->sub_ids_size(); ++i) {
-        auto &&sub_id(pub->sub_ids(i));
+    for (size_t i{0}; i < pub->consumer_group_ids_size(); ++i) {
+        auto &&consumer_group_id(pub->consumer_group_ids(i));
 
         uint64_t next_cursor_id;
-        ret = sync->GetCursorID(sub_id, req.queue_id(), next_cursor_id, false);
+        ret = sync->GetCursorID(consumer_group_id, req.queue_id(), next_cursor_id, false);
         if (0 < as_integer(ret)) {
-            QLWarn("GetCursorID ret %d sub_id %d queue_id %d", ret, sub_id, req.queue_id());
+            QLWarn("GetCursorID ret %d consumer_group_id %d queue_id %d", ret, consumer_group_id, req.queue_id());
             return false;
         } else if (0 == as_integer(ret) && cursor_id <= next_cursor_id) {
             QLInfo("add req skip. cursor_id %" PRIu64 " next_cursor_id %" PRIu64, cursor_id, next_cursor_id);
@@ -186,21 +186,21 @@ comm::RetCode BaseMgr::Get(const comm::proto::GetRequest &req, comm::proto::GetR
 
     SyncCtrl *sync = impl_->store->GetSyncCtrl();
 
-    if (as_integer(ret = sync->AdjustNextCursorID(req.sub_id(), req.queue_id(), cli_prev_cursor_id, cli_next_cursor_id)) < 0) {
+    if (as_integer(ret = sync->AdjustNextCursorID(req.consumer_group_id(), req.queue_id(), cli_prev_cursor_id, cli_next_cursor_id)) < 0) {
         comm::StoreBaseMgrBP::GetThreadInstance()->OnAdjustNextCursorIDFail(req);
-        QLErr("AdjustCur failed sub_id %d queue_id %d", req.sub_id(), req.queue_id());
+        QLErr("AdjustCur failed consumer_group_id %d queue_id %d", req.consumer_group_id(), req.queue_id());
         return comm::RetCode::RET_ERR_GET_ADJUST_CURSOR_ID_FAIL;
     } else if (as_integer(ret)) {
         comm::StoreBaseMgrBP::GetThreadInstance()->OnCursorIDNotFound(req);
-        QLInfo("cursorid not found. ret %d sub_id %d queue_id %d", as_integer(ret), req.sub_id(), req.queue_id());
+        QLInfo("cursorid not found. ret %d consumer_group_id %d queue_id %d", as_integer(ret), req.consumer_group_id(), req.queue_id());
         cli_prev_cursor_id = cli_next_cursor_id = -1;
     }
 
     if (cli_prev_cursor_id != req.prev_cursor_id() || cli_next_cursor_id != req.next_cursor_id()) {
         comm::StoreBaseMgrBP::GetThreadInstance()->OnCursorIDChange(req);
-        QLInfo("AdjustCur sub_id %d queue_id %d prev_cursor_id %" PRIu64
+        QLInfo("AdjustCur consumer_group_id %d queue_id %d prev_cursor_id %" PRIu64
                " -> %" PRIu64 " next_cursor_id %" PRIu64 " -> %" PRIu64,
-               req.sub_id(), req.queue_id(),
+               req.consumer_group_id(), req.queue_id(),
                static_cast<uint64_t>(req.prev_cursor_id()), cli_prev_cursor_id,
                static_cast<uint64_t>(req.next_cursor_id()), cli_next_cursor_id);
     }
@@ -237,9 +237,9 @@ comm::RetCode BaseMgr::Get(const comm::proto::GetRequest &req, comm::proto::GetR
         if (0 == get_loop_start_ts) get_loop_start_ts = now_ts;
         else if (get_loop_start_ts + get_loop_max_time_ms < now_ts) {
             comm::StoreBaseMgrBP::GetThreadInstance()->OnGetLoopReachMaxTime(req);
-            QLInfo("get loop reach max time. sub_id %d queue_id %d resp_item_size %d next_cursor_id %" PRIu64
+            QLInfo("get loop reach max time. consumer_group_id %d queue_id %d resp_item_size %d next_cursor_id %" PRIu64
                    " -> %" PRIu64,
-                   req.sub_id(), req.queue_id(), resp.items_size(),
+                   req.consumer_group_id(), req.queue_id(), resp.items_size(),
                    cli_next_cursor_id, next_cursor_id);
             break;
         }
@@ -272,9 +272,9 @@ comm::RetCode BaseMgr::Get(const comm::proto::GetRequest &req, comm::proto::GetR
 
 
         if (prev_cursor_id != -1 && prev_cursor_id >= cur_cursor_id) {
-            QLVerb("skip items, req.sub_id %d, prev_cursor_id %" PRIu64
+            QLVerb("skip items, req.consumer_group_id %d, prev_cursor_id %" PRIu64
                    " >= cur_cursor_id %" PRIu64,
-                   req.sub_id(), prev_cursor_id, cur_cursor_id);
+                   req.consumer_group_id(), prev_cursor_id, cur_cursor_id);
             next_cursor_id = cur_cursor_id;
             continue;
         }
@@ -319,12 +319,12 @@ comm::RetCode BaseMgr::Get(const comm::proto::GetRequest &req, comm::proto::GetR
 
 
         for (auto &&item : items) {
-            if (impl_->store->SkipGet(item, req) || topic_config->ShouldSkip(item, req.sub_id(), queue_info->queue_info_id())) {
+            if (impl_->store->SkipGet(item, req) || topic_config->ShouldSkip(item, req.consumer_group_id(), queue_info->queue_info_id())) {
                 comm::StoreBaseMgrBP::GetThreadInstance()->OnGetSkip(req, item);
                 QLVerb("skip item, uin %llu handle_id %d hash %" PRIu64
-                       " sub_ids %llu, request sub_id %d cur_cursor_id %" PRIu64,
+                       " consumer_group_ids %llu, request consumer_group_id %d cur_cursor_id %" PRIu64,
                        item.meta().uin(), item.meta().handle_id(),
-                       item.meta().hash(), item.sub_ids(), req.sub_id(),
+                       item.meta().hash(), item.consumer_group_ids(), req.consumer_group_id(),
                        cur_cursor_id);
                 continue;
             }
@@ -360,7 +360,7 @@ comm::RetCode BaseMgr::Get(const comm::proto::GetRequest &req, comm::proto::GetR
 
     if (prev_cursor_id != -1) {
         if (comm::RetCode::RET_OK !=
-            (ret = sync->UpdateCursorID(req.sub_id(), req.queue_id(), prev_cursor_id))) {
+            (ret = sync->UpdateCursorID(req.consumer_group_id(), req.queue_id(), prev_cursor_id))) {
             comm::StoreBaseMgrBP::GetThreadInstance()->OnUpdateCursorIDFail(req);
             QLErr("__UpdateCursorID ret %d queue_id %d prev_cursor_id %" PRIu64,
                   ret, req.queue_id(), prev_cursor_id);
@@ -370,7 +370,7 @@ comm::RetCode BaseMgr::Get(const comm::proto::GetRequest &req, comm::proto::GetR
 
     if (next_cursor_id != -1) {
         if (comm::RetCode::RET_OK !=
-            (ret = sync->UpdateCursorID(req.sub_id(), req.queue_id(), next_cursor_id, false))) {
+            (ret = sync->UpdateCursorID(req.consumer_group_id(), req.queue_id(), next_cursor_id, false))) {
             comm::StoreBaseMgrBP::GetThreadInstance()->OnUpdateCursorIDFail(req);
             QLErr("__UpdateCursorID ret %d queue_id %d next_cursor_id %" PRIu64,
                   ret, req.queue_id(), next_cursor_id);
@@ -382,9 +382,9 @@ comm::RetCode BaseMgr::Get(const comm::proto::GetRequest &req, comm::proto::GetR
         comm::StoreBaseMgrBP::GetThreadInstance()->OnItemInResp(req);
     }
 
-    QLInfo("Get end. sub_id %u queue_id %d prev_cursor_id %" PRIu64
+    QLInfo("Get end. consumer_group_id %u queue_id %d prev_cursor_id %" PRIu64
            " next_cursor_id %" PRIu64 " size %u",
-           req.sub_id(), req.queue_id(), prev_cursor_id, next_cursor_id, resp.items_size());
+           req.consumer_group_id(), req.queue_id(), prev_cursor_id, next_cursor_id, resp.items_size());
 
     comm::StoreBaseMgrBP::GetThreadInstance()->OnGetSucc(req, resp);
 

--- a/phxqueue/store/proto/store.proto
+++ b/phxqueue/store/proto/store.proto
@@ -6,11 +6,11 @@ import "phxqueue/comm/proto/comm.proto";
 message SyncCtrlInfo {
     message QueueDetail {
         optional int32 queue_id = 1;
-        message SubDetail {
-            optional int32 sub_id = 1;
+        message ConsumerGroupDetail {
+            optional int32 consumer_group_id = 1;
             optional uint64 prev_cursor_id = 2;
         }
-        repeated SubDetail sub_details = 2;
+        repeated ConsumerGroupDetail consumer_group_details = 2;
     }
     repeated QueueDetail queue_details = 1;
 }

--- a/phxqueue/store/store.cpp
+++ b/phxqueue/store/store.cpp
@@ -568,10 +568,10 @@ comm::RetCode Store::Get(const comm::proto::GetRequest &req, comm::proto::GetRes
 
     QLVerb("Get Succ. "
            "req: topic_id %d store_id %d queue_id %d limit %d atime %" PRIu64
-           " sub_id %d prev_cursor_id %" PRIu64 " next_cursor_id %" PRIu64 ". "
+           " consumer_group_id %d prev_cursor_id %" PRIu64 " next_cursor_id %" PRIu64 ". "
            "resp: items.size() %d prev_cursor_id %" PRIu64 " next_cursor_id %" PRIu64,
            req.topic_id(), req.store_id(), req.queue_id(), req.limit(),
-           req.atime(), req.sub_id(), req.prev_cursor_id(), req.next_cursor_id(),
+           req.atime(), req.consumer_group_id(), req.prev_cursor_id(), req.next_cursor_id(),
            resp.items_size(), resp.prev_cursor_id(), resp.next_cursor_id());
 
     return comm::RetCode::RET_OK;
@@ -586,7 +586,7 @@ bool Store::SkipGet(const comm::proto::QItem &item, const comm::proto::GetReques
         return true;
     }
 
-    if (0 == ((1ULL << (req.sub_id() - 1)) & item.sub_ids())) {
+    if (0 == ((1ULL << (req.consumer_group_id() - 1)) & item.consumer_group_ids())) {
         return true;
     }
 

--- a/phxqueue/store/storeoption.h
+++ b/phxqueue/store/storeoption.h
@@ -35,7 +35,7 @@ class StoreOption {
     int paxos_port{0};
 
     int ngroup{100};
-    int nsub{64};
+    int nconsumer_group{64};
     int nqueue{2000};
 
     int npaxos_iothread{3};

--- a/phxqueue/store/syncctrl.h
+++ b/phxqueue/store/syncctrl.h
@@ -34,19 +34,19 @@ class SyncCtrl {
     virtual ~SyncCtrl();
 
     comm::RetCode Init();
-    comm::RetCode AdjustNextCursorID(const int sub_id, const int queue_id,
+    comm::RetCode AdjustNextCursorID(const int consumer_group_id, const int queue_id,
                                      uint64_t &prev_cursor_id, uint64_t &next_cursor_id);
-    comm::RetCode UpdateCursorID(const int sub_id, const int queue_id,
+    comm::RetCode UpdateCursorID(const int consumer_group_id, const int queue_id,
                                  const uint64_t cursor_id, const bool is_prev = true);
-    comm::RetCode GetCursorID(const int sub_id, const int queue_id,
+    comm::RetCode GetCursorID(const int consumer_group_id, const int queue_id,
                               uint64_t &cursor_id, const bool is_prev = true) const;
     void ClearSyncCtrl();
     comm::RetCode GetBackLogByCursorID(const int queue_id, const uint64_t cursor_id, int &backlog);
     comm::RetCode SyncCursorID(const proto::SyncCtrlInfo &sync_ctrl_info);
 
   private:
-    comm::RetCode ClearCursorID(const int sub_id, const int queue_id);
-    comm::RetCode Flush(const int sub_id, const int queue_id);
+    comm::RetCode ClearCursorID(const int consumer_group_id, const int queue_id);
+    comm::RetCode Flush(const int consumer_group_id, const int queue_id);
 
     class SyncCtrlImpl;
     std::unique_ptr<SyncCtrlImpl> impl_;

--- a/phxqueue/test/check_config.cpp
+++ b/phxqueue/test/check_config.cpp
@@ -97,32 +97,32 @@ void CheckConfig::CheckTopicConfig(const int topic_id, const config::TopicConfig
         }
 
         {
-            std::set<int> sub_ids;
-            PHX_ASSERT(phxqueue::comm::as_integer(comm::RetCode::RET_OK), ==, phxqueue::comm::as_integer(topic_config->GetSubIDsByPubID(pub_id, sub_ids)));
-            PHX_ASSERT(pub->sub_ids_size(), ==, sub_ids.size());
-            for (int i{0}; i < pub->sub_ids_size(); ++i) {
-                auto sub_id = pub->sub_ids(i);
-                PHX_ASSERT(sub_ids.end() != sub_ids.find(sub_id), ==, true);
+            std::set<int> consumer_group_ids;
+            PHX_ASSERT(phxqueue::comm::as_integer(comm::RetCode::RET_OK), ==, phxqueue::comm::as_integer(topic_config->GetConsumerGroupIDsByPubID(pub_id, consumer_group_ids)));
+            PHX_ASSERT(pub->consumer_group_ids_size(), ==, consumer_group_ids.size());
+            for (int i{0}; i < pub->consumer_group_ids_size(); ++i) {
+                auto consumer_group_id = pub->consumer_group_ids(i);
+                PHX_ASSERT(consumer_group_ids.end() != consumer_group_ids.find(consumer_group_id), ==, true);
             }
         }
     }
 
-    // sub
-    std::vector<std::shared_ptr<const config::proto::Sub>> subs;
-    PHX_ASSERT(phxqueue::comm::as_integer(comm::RetCode::RET_OK), ==, phxqueue::comm::as_integer(topic_config->GetAllSub(subs)));
+    // consumer_group
+    std::vector<std::shared_ptr<const config::proto::ConsumerGroup>> consumer_groups;
+    PHX_ASSERT(phxqueue::comm::as_integer(comm::RetCode::RET_OK), ==, phxqueue::comm::as_integer(topic_config->GetAllConsumerGroup(consumer_groups)));
 
-    std::set<int> sub_ids;
-    PHX_ASSERT(phxqueue::comm::as_integer(comm::RetCode::RET_OK), ==, phxqueue::comm::as_integer(topic_config->GetAllSubID(sub_ids)));
-    PHX_ASSERT(subs.size(), ==, sub_ids.size());
-    for (auto &&sub : subs) {
-        auto sub_id = sub->sub_id();
-        PHX_ASSERT(sub_ids.end() != sub_ids.find(sub_id), ==, true);
-        PHX_ASSERT(topic_config->IsValidSubID(sub_id), ==, true);
+    std::set<int> consumer_group_ids;
+    PHX_ASSERT(phxqueue::comm::as_integer(comm::RetCode::RET_OK), ==, phxqueue::comm::as_integer(topic_config->GetAllConsumerGroupID(consumer_group_ids)));
+    PHX_ASSERT(consumer_groups.size(), ==, consumer_group_ids.size());
+    for (auto &&consumer_group : consumer_groups) {
+        auto consumer_group_id = consumer_group->consumer_group_id();
+        PHX_ASSERT(consumer_group_ids.end() != consumer_group_ids.find(consumer_group_id), ==, true);
+        PHX_ASSERT(topic_config->IsValidConsumerGroupID(consumer_group_id), ==, true);
 
         {
-            std::shared_ptr<const config::proto::Sub> tmp_sub;
-            PHX_ASSERT(phxqueue::comm::as_integer(comm::RetCode::RET_OK), ==, phxqueue::comm::as_integer(topic_config->GetSubBySubID(sub_id, tmp_sub)));
-            PHX_ASSERT(tmp_sub->sub_id(), ==, sub_id);
+            std::shared_ptr<const config::proto::ConsumerGroup> tmp_consumer_group;
+            PHX_ASSERT(phxqueue::comm::as_integer(comm::RetCode::RET_OK), ==, phxqueue::comm::as_integer(topic_config->GetConsumerGroupByConsumerGroupID(consumer_group_id, tmp_consumer_group)));
+            PHX_ASSERT(tmp_consumer_group->consumer_group_id(), ==, consumer_group_id);
         }
     }
 
@@ -173,9 +173,9 @@ void CheckConfig::CheckTopicConfig(const int topic_id, const config::TopicConfig
                 PHX_ASSERT(queue, >=, 0);
                 PHX_ASSERT(topic_config->IsValidQueue(queue), ==, true);
                 PHX_ASSERT(topic_config->IsValidQueue(queue, pub_id), ==, true);
-                for (int l{0}; l < pub->sub_ids_size(); ++l) {
-                    auto sub_id = pub->sub_ids(l);
-                    PHX_ASSERT(topic_config->IsValidQueue(queue, pub_id, sub_id), ==, true);
+                for (int l{0}; l < pub->consumer_group_ids_size(); ++l) {
+                    auto consumer_group_id = pub->consumer_group_ids(l);
+                    PHX_ASSERT(topic_config->IsValidQueue(queue, pub_id, consumer_group_id), ==, true);
                 }
 
                 {

--- a/phxqueue/test/simpleconsumer.cpp
+++ b/phxqueue/test/simpleconsumer.cpp
@@ -137,13 +137,13 @@ comm::RetCode SimpleConsumer::AcquireLock(const comm::proto::AcquireLockRequest 
 }
 
 void SimpleConsumer::BeforeLock(const comm::proto::ConsumerContext &cc) {
-    QLInfo("BeforeLock cc sub_id %d store_id %d queue_id %d",
-           cc.sub_id(), cc.store_id(), cc.queue_id());
+    QLInfo("BeforeLock cc consumer_group_id %d store_id %d queue_id %d",
+           cc.consumer_group_id(), cc.store_id(), cc.queue_id());
 }
 
 void SimpleConsumer::AfterLock(const comm::proto::ConsumerContext &cc) {
-    QLInfo("AfterLock cc sub_id %d store_id %d queue_id %d",
-           cc.sub_id(), cc.store_id(), cc.queue_id());
+    QLInfo("AfterLock cc consumer_group_id %d store_id %d queue_id %d",
+           cc.consumer_group_id(), cc.store_id(), cc.queue_id());
 }
 
 

--- a/phxqueue/test/simplehandler.cpp
+++ b/phxqueue/test/simplehandler.cpp
@@ -28,8 +28,8 @@ using namespace std;
 
 comm::HandleResult SimpleHandler::Handle(const comm::proto::ConsumerContext &cc,
                                          comm::proto::QItem &item, string &uncompressed_buffer) {
-    QLVerb("cc: sub_id %d store_id %d queue_id %d. item uin %" PRIu64,
-           cc.sub_id(), cc.store_id(), cc.queue_id(), (uint64_t)item.meta().uin());
+    QLVerb("cc: consumer_group_id %d store_id %d queue_id %d. item uin %" PRIu64,
+           cc.consumer_group_id(), cc.store_id(), cc.queue_id(), (uint64_t)item.meta().uin());
     return comm::HandleResult::RES_OK;
 }
 

--- a/phxqueue/test/test_config.cpp
+++ b/phxqueue/test/test_config.cpp
@@ -51,7 +51,7 @@ void TestConfig::TestTopicConfig(const config::TopicConfig *topic_config) {
     // 1->1, 2
     // 2->2
     const vector<int> expected_pub_ids = {1, 2};
-    const vector<int> expected_sub_ids = {1, 2};
+    const vector<int> expected_consumer_group_ids = {1, 2};
 
     /*************************** pub ****************************/
     // GetAllPub
@@ -84,44 +84,44 @@ void TestConfig::TestTopicConfig(const config::TopicConfig *topic_config) {
         assert(expected_pub_ids[0] == pub->pub_id());
     }
 
-    // GetSubIDsByPubID
+    // GetConsumerGroupIDsByPubID
     {
-        set<int> sub_ids;
+        set<int> consumer_group_ids;
         assert(comm::RetCode::RET_OK ==
-               topic_config->GetSubIDsByPubID(expected_pub_ids[0], sub_ids)); // 1->1,2
-        assert(expected_sub_ids.size() == sub_ids.size());
+               topic_config->GetConsumerGroupIDsByPubID(expected_pub_ids[0], consumer_group_ids)); // 1->1,2
+        assert(expected_consumer_group_ids.size() == consumer_group_ids.size());
     }
 
-    /*************************** sub ****************************/
+    /*************************** consumer_group ****************************/
 
-    // GetAllSub
+    // GetAllConsumerGroup
     {
-        vector<shared_ptr<const config::proto::Sub> > subs;
-        assert(comm::RetCode::RET_OK == topic_config->GetAllSub(subs));
-        assert(expected_sub_ids.size() == subs.size());
+        vector<shared_ptr<const config::proto::ConsumerGroup> > consumer_groups;
+        assert(comm::RetCode::RET_OK == topic_config->GetAllConsumerGroup(consumer_groups));
+        assert(expected_consumer_group_ids.size() == consumer_groups.size());
     }
 
-    // GetAllSubID
+    // GetAllConsumerGroupID
     {
-        set<int> sub_ids;
-        assert(comm::RetCode::RET_OK == topic_config->GetAllSubID(sub_ids));
-        assert(expected_sub_ids.size() == sub_ids.size());
+        set<int> consumer_group_ids;
+        assert(comm::RetCode::RET_OK == topic_config->GetAllConsumerGroupID(consumer_group_ids));
+        assert(expected_consumer_group_ids.size() == consumer_group_ids.size());
     }
 
 
-    // IsValidSubID
+    // IsValidConsumerGroupID
     {
-        for (auto &&sub_id : expected_sub_ids) {
-            assert(topic_config->IsValidSubID(sub_id));
+        for (auto &&consumer_group_id : expected_consumer_group_ids) {
+            assert(topic_config->IsValidConsumerGroupID(consumer_group_id));
         }
     }
 
-    // GetSubBySubID
+    // GetConsumerGroupByConsumerGroupID
     {
-        shared_ptr<const config::proto::Sub> sub;
-        assert(comm::RetCode::RET_OK == topic_config->GetSubBySubID(expected_sub_ids[0], sub));
-        assert(sub);
-        assert(expected_sub_ids[0] == sub->sub_id());
+        shared_ptr<const config::proto::ConsumerGroup> consumer_group;
+        assert(comm::RetCode::RET_OK == topic_config->GetConsumerGroupByConsumerGroupID(expected_consumer_group_ids[0], consumer_group));
+        assert(consumer_group);
+        assert(expected_consumer_group_ids[0] == consumer_group->consumer_group_id());
     }
 
     /*************************** queue_info ****************************/

--- a/phxqueue/test/test_get_queues_by_pub_id_main.cpp
+++ b/phxqueue/test/test_get_queues_by_pub_id_main.cpp
@@ -58,7 +58,7 @@ int GetStoreIDAndQueueIDPairsByPubID(const int topic_id, const int pub_id, set<p
 
         set<int> queue_ids;
         if (comm::RetCode::RET_OK != (ret = topic_config->GetQueuesByQueueInfoID(queue_info_id, queue_ids))) {
-            NLErr("GetSubIDsByPubID ret %d pub_id %d", as_integer(ret), pub_id);
+            NLErr("GetConsumerGroupIDsByPubID ret %d pub_id %d", as_integer(ret), pub_id);
             continue;
         }
 

--- a/phxqueue/test/test_store_main.cpp
+++ b/phxqueue/test/test_store_main.cpp
@@ -43,7 +43,7 @@ void TestAdd(store::Store &store) {
     const uint64_t uin = 123;
     const string buffer = "123";
     const int buffer_type = 0;
-    const uint64_t sub_ids = 3;
+    const uint64_t consumer_group_ids = 3;
 
     comm::proto::AddRequest req;
     comm::proto::AddResponse resp;
@@ -58,7 +58,7 @@ void TestAdd(store::Store &store) {
     meta->set_uin(uin);
     item->set_buffer(buffer);
     item->set_buffer_type(buffer_type);
-    item->set_sub_ids(sub_ids);
+    item->set_consumer_group_ids(consumer_group_ids);
     item->set_pub_id(pub_id);
     item->set_atime(time(nullptr));
 
@@ -105,7 +105,7 @@ void StoreRun(const int vpid) {
     opt.port = stores[0]->addrs(vpid).port();
     opt.paxos_port = stores[0]->addrs(vpid).paxos_port();
     opt.ngroup = 1;
-    opt.nsub = 2;
+    opt.nconsumer_group = 2;
     opt.log_func = log_func;
 
     NLVerb("store %d opt done", vpid);

--- a/phxqueue_phxrpc/test/echo_handler.cpp
+++ b/phxqueue_phxrpc/test/echo_handler.cpp
@@ -29,8 +29,8 @@ using namespace std;
 
 comm::HandleResult EchoHandler::Handle(const comm::proto::ConsumerContext &cc,
                                        comm::proto::QItem &item, string &uncompressed_buffer) {
-    printf("consume echo \"%s\" succeeded! sub_id %d store_id %d queue_id %d item_uin %" PRIu64 "\n",
-           item.buffer().c_str(), cc.sub_id(), cc.store_id(), cc.queue_id(), (uint64_t)item.meta().uin());
+    printf("consume echo \"%s\" succeeded! consumer_group_id %d store_id %d queue_id %d item_uin %" PRIu64 "\n",
+           item.buffer().c_str(), cc.consumer_group_id(), cc.store_id(), cc.queue_id(), (uint64_t)item.meta().uin());
     fflush(stdout);
     return comm::HandleResult::RES_OK;
 }

--- a/phxqueue_phxrpc/test/etc/consumerconfig.conf
+++ b/phxqueue_phxrpc/test/etc/consumerconfig.conf
@@ -8,7 +8,7 @@
                 "port": "8001"
             },
             "scale": "1000",
-            "sub_ids": [1, 2]
+            "consumer_group_ids": [1, 2]
         },
         {
             "addr":
@@ -17,7 +17,7 @@
                 "port": "8002"
             },
             "scale": "1000",
-            "sub_ids": [1, 2]
+            "consumer_group_ids": [1, 2]
         },        
         {
             "addr":
@@ -26,7 +26,7 @@
                 "port": "8003"
             },
             "scale": "1000",
-            "sub_ids": [1, 2]
+            "consumer_group_ids": [1, 2]
         }
     ]
 }

--- a/phxqueue_phxrpc/test/etc/topicconfig.conf
+++ b/phxqueue_phxrpc/test/etc/topicconfig.conf
@@ -30,24 +30,24 @@
     [
         {
             "pub_id": "1",
-            "sub_ids": ["1", "2"],
+            "consumer_group_ids": ["1", "2"],
             "queue_info_ids": ["1", "3"]
         },
         {
             "pub_id": "2",
-            "sub_ids": ["2"],
+            "consumer_group_ids": ["2"],
             "queue_info_ids": ["2", "4"]
         }
     ],
-    "subs":
+    "consumer_groups":
     [
         {
-            "sub_id": "1",
+            "consumer_group_id": "1",
             "use_dynamic_scale": "0",
             "skip_lock": "1"
         },
         {
-            "sub_id": "2",
+            "consumer_group_id": "2",
             "use_dynamic_scale": "0",
             "skip_lock": "1"
         }

--- a/phxqueue_phxrpc/test/test_get_main.cpp
+++ b/phxqueue_phxrpc/test/test_get_main.cpp
@@ -1,0 +1,151 @@
+/*
+Tencent is pleased to support the open source community by making PhxQueue available.
+Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the BSD 3-Clause License (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+
+<https://opensource.org/licenses/BSD-3-Clause>
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+*/
+
+
+#include <cinttypes>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <errno.h>
+#include <fcntl.h>
+#include <iostream>
+#include <memory>
+#include <netinet/in.h>
+#include <poll.h>
+#include <sys/socket.h>
+#include <time.h>
+#include <unistd.h>
+
+
+#include "phxqueue/comm.h"
+#include "phxqueue/plugin.h"
+#include "phxqueue/store.h"
+#include "phxqueue_phxrpc/comm.h"
+#include "phxqueue_phxrpc/config.h"
+#include "phxqueue_phxrpc/plugin.h"
+
+#include "phxqueue_phxrpc/app/store/store_client.h"
+
+
+using namespace phxqueue;
+using namespace phxqueue_phxrpc;
+using namespace std;
+
+void ShowUsage(const char *proc) {
+    printf("\t%s -f <global_config_path> -t <topic_id> -s <store_id> -q <queue_id> -c <consumer_group_id> [-r (random get)]\n", proc);
+}
+
+phxqueue::comm::RetCode Get(const phxqueue::comm::proto::GetRequest &req,
+                            phxqueue::comm::proto::GetResponse &resp) {
+
+    static __thread StoreClient store_client;
+    auto ret = store_client.ProtoGet(req, resp);
+    if (phxqueue::comm::RetCode::RET_OK != ret) {
+        NLErr("ProtoGet ret %d", phxqueue::comm::as_integer(ret));
+    }
+    return ret;
+}
+
+void PrintItems(const phxqueue::comm::proto::GetResponse &resp) {
+    NLInfo("items_size %d", (int)resp.items_size());
+    for (size_t i{0}; i < resp.items_size(); ++i) {
+        auto &&item = resp.items(i);
+        NLInfo("cursor_id %" PRIu64 " buf %s", (uint64_t)item.cursor_id(), item.buffer().c_str());
+    }
+}
+
+
+phxqueue::comm::RetCode OneCall(phxqueue::comm::proto::GetRequest &req, phxqueue::comm::proto::GetResponse &resp) {
+    phxqueue::store::StoreMasterClient<phxqueue::comm::proto::GetRequest, phxqueue::comm::proto::GetResponse> store_master_client;
+    phxqueue::comm::RetCode ret = store_master_client.ClientCall(req, resp, bind(&Get, placeholders::_1, placeholders::_2));
+
+
+
+    return ret;
+}
+
+
+int main(int argc, char ** argv) {
+    const char *global_config_path = nullptr;
+    int topic_id = -1;
+    int store_id = -1;
+    int queue_id = -1;
+    int consumer_group_id = -1;
+    bool random = false;
+
+    for (int i = 0; i < argc; ++i) {
+		if (strcmp(argv[i], "--help") == 0) {
+			ShowUsage(argv[0]);
+			return 0;
+		} else if (strcmp(argv[i], "-f") == 0) {
+            global_config_path = argv[++i];
+            continue;
+        } else if (strcmp(argv[i], "-t") == 0) {
+            topic_id = std::atoi(argv[++i]);
+            continue;
+        } else if (strcmp(argv[i], "-s") == 0) {
+            store_id = std::atoi(argv[++i]);
+            continue;
+        }  else if (strcmp(argv[i], "-q") == 0) {
+            queue_id = std::atoi(argv[++i]);
+            continue;
+        }  else if (strcmp(argv[i], "-c") == 0) {
+            consumer_group_id = std::atoi(argv[++i]);
+            continue;
+        } else if (strcmp(argv[i], "-r") == 0) {
+            random = true;
+            continue;
+        }
+    }
+
+    if (nullptr == global_config_path || -1 == topic_id || -1 == store_id || -1 == queue_id || -1 == consumer_group_id) {
+        ShowUsage(argv[0]);
+        return 0;
+    }
+
+
+    phxqueue::comm::Logger::GetInstance()->SetLogFunc([](const int log_level, const char *format, va_list args)->void {
+            if (log_level <= static_cast<int>(phxqueue::comm::LogLevel::Error)) return;
+            vprintf(format, args);
+            printf("\n");
+        });
+
+
+    phxqueue::comm::proto::GetRequest req;
+    phxqueue::comm::proto::GetResponse resp;
+
+    req.set_topic_id(topic_id);
+    req.set_store_id(store_id);
+    req.set_queue_id(queue_id);
+    req.set_limit(100);
+    req.set_consumer_group_id(consumer_group_id);
+    req.set_prev_cursor_id(-1);
+    req.set_next_cursor_id(-1);
+    req.set_random(random);
+
+    while (1) {
+        auto ret = OneCall(req, resp);
+        NLInfo("Dequeue ret %d", phxqueue::comm::as_integer(ret));
+
+        req.set_prev_cursor_id(resp.next_cursor_id());
+        req.set_next_cursor_id(resp.next_cursor_id());
+
+
+        if (phxqueue::comm::as_integer(ret) < 0) break;
+        PrintItems(resp);
+
+        sleep(1);
+        //if (0 == resp.items_size()) break;
+    }
+
+
+    return 0;
+}
+


### PR DESCRIPTION
a. Change defination 'sub' 'to consumer_group'.

```
Purpose:
1. Align the definition of kafka in order to make better understanding.
2. Retain the 'sub' configuration. In the next version, by configure the ip/port of a http service in 'sub', consumer can push out-queued data to the service.
```

b. Store supports random reads, not just sequential reads.

```
Purpose: Prepare for the next support for the mqtt protocol.
```